### PR TITLE
[FIX] check partition using e2fsck before resize

### DIFF
--- a/resize_data_part.target-sh
+++ b/resize_data_part.target-sh
@@ -65,6 +65,10 @@ fi
 resizepart /dev/${DEVICE} ${PART_NUM} ${SIZE}
 echo
 
+# Check partition to prevent resize from failling
+e2fsck -f /dev/${DEVICE}p${PART_NUM}
+
+# Then resize
 resize2fs /dev/${DEVICE}p${PART_NUM}
 
 # Clear the trap that attempts to mount the partition.


### PR DESCRIPTION
most of the time, partition resizing failed, as suggested by resize2fs error message I check partition before resizing.